### PR TITLE
Implemented „-autoconnect“ in WeeChat Config Example

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ $GOPATH/bin/robustirc-bridge -network=<span class="network">robustirc.net</span>
 /server add -auto -network <span class="networkname">robustirc</span> localhost 6667
 /connect <span class="networkname">robustirc</span></pre>
   <pre style="text-align: left; display: none" class="instructions-WeeChat">/proxy add bridge socks5 localhost 1080
-/server add <span class="networkname">robustirc</span> <span class="network">robustirc.net</span>
+/server add <span class="networkname">robustirc</span> <span class="network">robustirc.net</span> -autoconnect
 /set irc.server.<span class="networkname">robustirc</span>.proxy bridge
 /connect <span class="networkname">robustirc</span></pre>
 </div>


### PR DESCRIPTION
This „-auto“ option should be consistent in the WeeChat and Irssi
Example.
